### PR TITLE
Add resource to acquire and release locks

### DIFF
--- a/lib/puppet/provider/consul_kv_lock/default.rb
+++ b/lib/puppet/provider/consul_kv_lock/default.rb
@@ -1,0 +1,19 @@
+require 'puppet/provider/blocker'
+Puppet::Type.type(:consul_kv_lock).provide(
+  :default,
+  :parent => Puppet::Type.type(:consul_kv).provider(:default)
+) do
+
+  # should not fail if we current have the lock
+  def acquire_lock(tries = resource[:tries], try_sleep = resource[:try_sleep])
+    Puppet::Provider::Blocker.new.block_until_ready(tries, try_sleep) do
+      return true if !(createKV(resource[:name], 'locked',
+        {
+          :acquire => resource[:session_name],
+        }
+      ) == 'false')
+    end
+    fail("Could not acquire lock")
+  end
+
+end

--- a/lib/puppet/provider/consul_kv_release/default.rb
+++ b/lib/puppet/provider/consul_kv_release/default.rb
@@ -1,0 +1,16 @@
+require 'puppet/provider/blocker'
+Puppet::Type.type(:consul_kv_release).provide(
+  :default,
+  :parent => Puppet::Type.type(:consul_kv).provider(:default)
+) do
+
+  # should not fail if we current have the lock
+  def release_lock
+    result = !(createKV(resource[:name], 'locked',
+      {
+        :release => resource[:session_name],
+      }
+    ) == 'false')
+  end
+
+end

--- a/lib/puppet/type/consul_kv_lock.rb
+++ b/lib/puppet/type/consul_kv_lock.rb
@@ -1,0 +1,44 @@
+Puppet::Type.newtype(:consul_kv_lock) do
+
+  desc <<-'EOD'
+  Aquire a lock for the specified session name
+  EOD
+
+  newparam(:name, :namevar => true) do
+    desc 'Consul Key name'
+  end
+
+  newparam(:url) do
+    desc 'Consul url to use'
+    defaultto 'http://localhost:8500/v1/kv'
+  end
+
+  newparam(:session_name) do
+    desc 'name of the session to release'
+  end
+
+  newparam(:tries) do
+    desc 'How many times to retry'
+    defaultto 40
+    munge do |v|
+      Integer(v)
+    end
+  end
+
+  newparam(:try_sleep) do
+    desc 'how long to wait between retries'
+    defaultto 3
+    munge do |v|
+      Integer(v)
+    end
+  end
+
+  def refresh
+    provider.acquire_lock
+  end
+
+  autorequire(:consul_session) do
+    self[:session_name]
+  end
+
+end

--- a/lib/puppet/type/consul_kv_release.rb
+++ b/lib/puppet/type/consul_kv_release.rb
@@ -1,0 +1,29 @@
+Puppet::Type.newtype(:consul_kv_release) do
+
+  desc <<-'EOD'
+  Release a lock help by the specified session name. This resource only
+  suports a refresh-mode and does not perform regular resource management.
+  EOD
+
+  newparam(:name, :namevar => true) do
+    desc 'Consul Key name'
+  end
+
+  newparam(:url) do
+    desc 'Consul url to use'
+    defaultto 'http://localhost:8500/v1/kv'
+  end
+
+  newparam(:session_name) do
+    desc 'name of the session to release'
+  end
+
+  newparam(:fail_if_not_held) do
+    desc 'fail if the expected lock is not held'
+  end
+
+  def refresh
+    provider.release_lock
+  end
+
+end


### PR DESCRIPTION
So that we can coordinate service restarts
across clusters to ensure that only one
node can restart at a time.

TODO - there are still a few more things to understand:

1. the failure cases. especially cases where we want to
acquire the lock, but we already have it, and the case
where we try to release a lock that we don't have.

2. I am not sure when we should release locks (ie:
   if lock release should be idempotent). Failures of
   any of these resources probably needs to be cleaned
   up manually until we better understand these operations.